### PR TITLE
Initial implementation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+BasedOnStyle: Google
+ColumnLimit: 100
+CommentPragmas: '^ SPDX'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+obj
+*.so
+test-morello-hybrid
+test-morello-purecap

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ obj
 *.so
 test-morello-hybrid
 test-morello-purecap
+example-*-morello-hybrid
+example-*-morello-purecap

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,17 @@ MORELLO_HYBRID := --config cheribsd-morello-hybrid.cfg
 all: test-morello-purecap test-morello-hybrid libcapmap-morello-purecap.so libcapmap-morello-hybrid.so examples-morello-purecap examples-morello-hybrid
 
 clean:
-	rm -rf obj test-morello-purecap test-morello-hybrid libcapmap-*.so
+	rm -rf obj test-morello-purecap test-morello-hybrid libcapmap-*.so example-*-morello-*
 
 clang-format:
 	$(SDKPREFIX)clang-format -i tests/*.cc tests/*.h include/*.h src/*.cc
 
 clang-format-check:
 	@! $(SDKPREFIX)clang-format -output-replacements-xml tests/*.cc tests/*.h include/*.h src/*.cc | grep -c '<replacement ' > /dev/null
+
+examples-morello-purecap: $(patsubst examples/%.cc,example-%-morello-purecap,$(wildcard examples/*.cc))
+
+examples-morello-hybrid: $(patsubst examples/%.cc,example-%-morello-hybrid,$(wildcard examples/*.cc))
 
 
 
@@ -33,6 +37,9 @@ OBJS_MORELLO_PURECAP := $(patsubst src/%.cc,obj/morello-purecap/%.o,$(wildcard s
 libcapmap-morello-purecap.so: $(OBJS_MORELLO_PURECAP) include/*.h
 	$(SDKPREFIX)clang++ -fPIC -shared $(CFLAGS) $(MORELLO_PURECAP) -lutil -I. $(OBJS_MORELLO_PURECAP) -std=c++14 -o $@
 
+example-%-morello-purecap: examples/%.cc include/*.h libcapmap-morello-purecap.so
+	$(SDKPREFIX)clang++ -Wl,-rpath,. -L. -lcapmap-morello-purecap $(CFLAGS) $(MORELLO_PURECAP) -I. $< -std=c++14 -o $@
+
 
 
 test-morello-hybrid: libcapmap-morello-hybrid.so tests/*.cc tests/*.h
@@ -45,3 +52,6 @@ obj/morello-hybrid/%.o: src/%.cc include/*.h
 OBJS_MORELLO_HYBRID := $(patsubst src/%.cc,obj/morello-hybrid/%.o,$(wildcard src/*.cc))
 libcapmap-morello-hybrid.so: $(OBJS_MORELLO_HYBRID) include/*.h
 	$(SDKPREFIX)clang++ -fPIC -shared $(CFLAGS) $(MORELLO_HYBRID) -lutil -I. $(OBJS_MORELLO_HYBRID) -std=c++14 -o $@
+
+example-%-morello-hybrid: examples/%.cc include/*.h libcapmap-morello-hybrid.so
+	$(SDKPREFIX)clang++ -Wl,-rpath,. -L. -lcapmap-morello-hybrid $(CFLAGS) $(MORELLO_HYBRID) -I. $< -std=c++14 -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+CHERI ?= $(HOME)/cheri
+SDKPREFIX ?= $(CHERI)/output/morello-sdk/bin/
+CFLAGS ?= -Wall -Wextra -pedantic -O1 -g
+MORELLO_PURECAP := --config cheribsd-morello-purecap.cfg
+MORELLO_HYBRID := --config cheribsd-morello-hybrid.cfg
+
+.PHONY: all clean clang-format clang-format-check examples-morello-purecap examples-morello-hybrid
+
+all: test-morello-purecap test-morello-hybrid libcapmap-morello-purecap.so libcapmap-morello-hybrid.so examples-morello-purecap examples-morello-hybrid
+
+clean:
+	rm -rf obj test-morello-purecap test-morello-hybrid libcapmap-*.so
+
+clang-format:
+	$(SDKPREFIX)clang-format -i tests/*.cc tests/*.h include/*.h src/*.cc
+
+clang-format-check:
+	@! $(SDKPREFIX)clang-format -output-replacements-xml tests/*.cc tests/*.h include/*.h src/*.cc | grep -c '<replacement ' > /dev/null
+
+
+
+test-morello-purecap: libcapmap-morello-purecap.so tests/*.cc tests/*.h
+	$(SDKPREFIX)clang++ -Wl,-rpath,. -L. -lcapmap-morello-purecap $(CFLAGS) $(MORELLO_PURECAP) -I. tests/*.cc -std=c++14 -o $@
+
+obj/morello-purecap/%.o: src/%.cc include/*.h
+	@mkdir -p obj/morello-purecap
+	$(SDKPREFIX)clang++ -fPIC $(CFLAGS) $(MORELLO_PURECAP) -I. $< -std=c++14 -c -o $@
+
+OBJS_MORELLO_PURECAP := $(patsubst src/%.cc,obj/morello-purecap/%.o,$(wildcard src/*.cc))
+libcapmap-morello-purecap.so: $(OBJS_MORELLO_PURECAP) include/*.h
+	$(SDKPREFIX)clang++ -fPIC -shared $(CFLAGS) $(MORELLO_PURECAP) -lutil -I. $(OBJS_MORELLO_PURECAP) -std=c++14 -o $@
+
+
+
+test-morello-hybrid: libcapmap-morello-hybrid.so tests/*.cc tests/*.h
+	$(SDKPREFIX)clang++ -Wl,-rpath,. -L. -lcapmap-morello-hybrid $(CFLAGS) $(MORELLO_HYBRID) -I. tests/*.cc -std=c++14 -o $@
+
+obj/morello-hybrid/%.o: src/%.cc include/*.h
+	@mkdir -p obj/morello-hybrid
+	$(SDKPREFIX)clang++ -fPIC $(CFLAGS) $(MORELLO_HYBRID) -I. $< -std=c++14 -c -o $@
+
+OBJS_MORELLO_HYBRID := $(patsubst src/%.cc,obj/morello-hybrid/%.o,$(wildcard src/*.cc))
+libcapmap-morello-hybrid.so: $(OBJS_MORELLO_HYBRID) include/*.h
+	$(SDKPREFIX)clang++ -fPIC -shared $(CFLAGS) $(MORELLO_HYBRID) -lutil -I. $(OBJS_MORELLO_HYBRID) -std=c++14 -o $@

--- a/examples/default.cc
+++ b/examples/default.cc
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#include <stdio.h>
+
+#include "include/capmap.h"
+
+int main() {
+  printf("Example: default process capability map.\n");
+  capmap::simple_scan_and_print_json(stdout);
+}

--- a/include/capmap-mappings.h
+++ b/include/capmap-mappings.h
@@ -78,6 +78,21 @@ class LoadCapMap : public Map {
   SparseRange ranges_;
 };
 
+// Memory ranges from which data can be loaded.
+class LoadMap : public Map {
+ public:
+  virtual char const *name() const override { return "load"; }
+  virtual char const *address_space() const override { return "virtual memory"; }
+  virtual std::set<Range> const &ranges() const override { return ranges_.parts(); }
+  virtual bool try_combine(void *__capability cap) override;
+  virtual ~LoadMap() {}
+
+  SparseRange const &sparse_range() const { return ranges_; }
+
+ private:
+  SparseRange ranges_;
+};
+
 // TODO: Provide other `Map` derivatives.
 
 }  // namespace capmap

--- a/include/capmap-mappings.h
+++ b/include/capmap-mappings.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#ifndef CAPMAP_MAPPERS_H_
+#define CAPMAP_MAPPERS_H_
+
+#include "capmap-range.h"
+
+namespace capmap {
+
+// A map, with a custom combination function.
+//
+// Every time the `Mapper` finds a capability, it asks each of its mappers to
+// combine it by calling `try_combine()`.
+class Map {
+ public:
+  // Return a user-facing name for the map.
+  virtual char const *name() const = 0;
+
+  // Return a user-facing address space name for the map.
+  virtual char const *address_space() const = 0;
+
+  // All ranges included in the map.
+  //
+  // Whilst most maps will merge adjacent or overlapping ranges, like SparseRange,
+  // some might preserve the individual ranges. This is useful for execution
+  // permissions, for example.
+  //
+  // TODO: This doesn't actually work for Execute, because we can't store those
+  // in a std::set. Differently-overlapping ranges are relevant for Execute, so
+  // we need a better way to represent them. Do we need some abstract iterator
+  // type?
+  virtual std::set<Range> const &ranges() const = 0;
+
+  // If the capability has the necessary permissions, add it to the map.
+  //
+  // The implementation may shrink the range first, for example to apply
+  // alignment constraints required by the permissions being mapped.
+  //
+  // Returns true if the capability had the necessary permissions and was
+  // combined (even if shrunk for alignment or if the resulting map already
+  // included it), and false otherwise.
+  virtual bool try_combine(void *__capability cap) = 0;
+
+  virtual ~Map(){};
+};
+
+// Memory ranges from which capabilities can be loaded.
+//
+// This requires the necessary permissions, but it also contracts the bounds to
+// ensure that they're aligned.
+class LoadCapMap : public Map {
+ public:
+  virtual char const *name() const override { return "load capabilities"; }
+  virtual char const *address_space() const override { return "virtual memory"; }
+  virtual std::set<Range> const &ranges() const override { return ranges_.parts(); }
+
+  virtual bool try_combine(void *__capability cap) override;
+
+  virtual ~LoadCapMap() {}
+
+  // If `addr` refers to an area of memory that might contain a capability that
+  // we haven't already scanned, return false, and leave `*cont` unmodified.
+  //
+  // Otherwise, return true, and set `*cont` to point to the next address that a
+  // scan for new capability might continue from. This will typically be the
+  // first capability-aligned excluded address after `addr`, but in some cases
+  // (e.g. if the map covers the whole address space), it may still be included.
+  bool includes_cap(ptraddr_t addr, ptraddr_t *cont) const;
+
+  // Return a SparseRange representing all mapped regions from which
+  // capabilities could be loaded (at the page table level).
+  static SparseRange vmmap();
+
+  SparseRange const &sparse_range() const { return ranges_; }
+
+ private:
+  SparseRange ranges_;
+};
+
+// TODO: Provide other `Map` derivatives.
+
+}  // namespace capmap
+#endif

--- a/include/capmap-range.h
+++ b/include/capmap-range.h
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#ifndef CAPMAP_RANGE_H_
+#define CAPMAP_RANGE_H_
+
+#if __has_feature(capabilities)
+#include <cheriintrin.h>
+#else
+#error "capmap.h requires capabilities"
+#endif
+
+#include <assert.h>
+
+#include <set>
+
+namespace capmap {
+
+// A contiguous range over some address space.
+//
+// Address spaces are assumed to be completely addressable by ptraddr_t, and
+// the length of a range is assumed to be representable by size_t.
+class Range {
+ public:
+  // Derive a Range from a capability's bounds.
+  static Range from_cap(void *__capability cap);
+
+  // [base,last].
+  static Range from_base_last(ptraddr_t base, ptraddr_t last) {
+    Range r;
+    r.base_ = base;
+    r.last_ = last;
+    return r;
+  }
+
+  // [base,limit).
+  static Range from_base_limit(ptraddr_t base, ptraddr_t limit) {
+    return from_base_last(base, limit - 1);
+  }
+
+  // [base,base+length).
+  static Range from_base_length(ptraddr_t base, size_t length) {
+    return from_base_last(base, base + length - 1);
+  }
+
+  // The full 64-bit address space.
+  static Range full_64bit() { return from_base_last(0, UINT64_MAX); }
+
+  // A range covering the C++ object pointer to by `ptr`.
+  //
+  // This considers only (C++) type information, and ignores capability bounds.
+  template <typename T>
+  static Range from_object(T const *ptr) {
+#ifdef __CHERI_PURE_CAPABILITY__
+    ptraddr_t base = cheri_address_get(ptr);
+#else
+    ptraddr_t base = reinterpret_cast<ptraddr_t>(ptr);
+#endif
+    return from_base_length(base, sizeof(T));
+  }
+
+  // An arbitrary empty range.
+  Range() : base_(UINT64_MAX), last_(0) {}
+
+  // Align the base up, and the limit down, to the specified alignment.
+  //
+  // `multiple` must be a power of two.
+  //
+  // Empty ranges remain unmodified because it is not always possible to align
+  // them if either bound wraps.
+  void shrink_to_alignment(size_t multiple) {
+    assert(__builtin_popcount(multiple) == 1);  // Power of two.
+    if (!is_empty()) {
+      base_ = cheri_align_up(base_, multiple);
+      last_ = cheri_align_down(last_ + 1, multiple) - 1;
+    }
+  }
+
+  Range shrunk_to_alignment(size_t multiple) const {
+    Range r = *this;
+    r.shrink_to_alignment(multiple);
+    return r;
+  }
+
+  bool overlaps(Range other) const { return (base_ <= other.last_) && (last_ >= other.base_); }
+  bool includes(Range other) const { return (base_ <= other.base_) && (last_ >= other.last_); }
+  bool includes(ptraddr_t addr) const { return (base_ <= addr) && (last_ >= addr); }
+
+  bool follows(Range other) const { return (base_ > 0) && (base_ == other.last_ + 1); }
+  bool preceeds(Range other) const { return other.follows(*this); }
+
+  // If {*this, other} describes a single contiguous range, modify *this to be
+  // that range (and return true).
+  bool try_combine(Range other);
+
+  bool is_empty() const { return last_ < base_; }
+  ptraddr_t base() const { return base_; }
+  ptraddr_t last() const { return last_; }
+  std::pair<bool, ptraddr_t> limit() const {
+    ptraddr_t limit = last_ + 1;
+    return std::make_pair(limit < last_, limit);
+  }
+  std::pair<bool, size_t> length() const {
+    if (is_empty()) return std::make_pair(false, 0);
+    bool bit64 = (base_ == 0) && (last_ == UINT64_MAX);
+    return std::make_pair(bit64, last_ - base_ + 1);
+  }
+
+  bool operator==(Range other) const { return (base_ == other.base_) && (last_ == other.last_); }
+  bool operator!=(Range other) const { return !(operator==(other)); }
+
+  // Provide an ordering, for fast look-up in sorted containers.
+  //
+  // Sorting only on `last_` is important; we use it to simplify SparseRange
+  // operations.
+  //
+  // Note that ranges that compare less-than might still overlap. See
+  // `preceeds()` if you need to check that a range is immediately before
+  // another, without overlaps.
+  bool operator<(Range other) const { return last_ < other.last_; }
+
+ private:
+  ptraddr_t base_;
+  ptraddr_t last_;
+};
+
+void print_json(FILE *stream, std::set<Range> const &ranges, char const *line_prefix = "");
+
+// Zero or more non-empty, non-overlapping, non-adjacent ranges, sorted by
+// address.
+//
+// Combining or removing ranges automatically merges or splits sub-ranges, as
+// required. This is used for performing set-like operations on address spaces,
+// for example to determine what to scan.
+class SparseRange {
+ public:
+  SparseRange() {}
+  SparseRange(Range range) { combine(range); }
+
+  bool is_empty() const { return ranges_.empty(); }
+  bool is_contiguous() const { return ranges_.size() == 1; }
+
+  void combine(Range range);
+  void remove(Range range);
+
+  void combine(SparseRange ranges) {
+    for (auto range : ranges.parts()) combine(range);
+  }
+  void remove(SparseRange ranges) { remove(ranges.parts()); }
+  void remove(std::set<Range> const &ranges) {
+    for (auto range : ranges) remove(range);
+  }
+
+  bool overlaps(Range other) const;
+  bool includes(Range other) const;
+  bool includes(ptraddr_t addr) const { return includes(Range::from_base_last(addr, addr)); }
+
+  bool includes(SparseRange other) const {
+    for (auto range : other.parts()) {
+      if (!includes(range)) return false;
+    }
+    return true;
+  }
+
+  std::set<Range> const &parts() const { return ranges_; }
+
+  bool operator==(const SparseRange &other) const { return ranges_ == other.ranges_; }
+  bool operator!=(const SparseRange &other) const { return !(operator==(other)); }
+
+  void print_json(FILE *stream, char const *line_prefix = "") {
+    ::capmap::print_json(stream, parts(), line_prefix);
+  }
+
+ private:
+  std::set<Range> ranges_;
+};
+
+}  // namespace capmap
+#endif

--- a/include/capmap.h
+++ b/include/capmap.h
@@ -46,6 +46,17 @@ struct Roots {
 // caller-saved registers may be missed.
 __attribute((naked)) Roots get_roots();
 
+// Shorthand for creating a new Mapper, scanning all roots from `get_roots()`,
+// then calling `print_json()`.
+//
+// This is useful for simple applications and quick tests, but it only scans for
+// the default permissions (notably "load capability") and doesn't allow any
+// customisation.
+//
+// Note that argument passing and other compiler behaviours may hide
+// capabilities left in caller-saved registers.
+void simple_scan_and_print_json(FILE *stream);
+
 // The primary container, and expected API entry point.
 class Mapper {
  public:

--- a/include/capmap.h
+++ b/include/capmap.h
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#ifndef CAPMAP_H_
+#define CAPMAP_H_
+
+#include "capmap-range.h"
+
+#endif

--- a/include/capmap.h
+++ b/include/capmap.h
@@ -4,6 +4,93 @@
 #ifndef CAPMAP_H_
 #define CAPMAP_H_
 
+#include "capmap-mappings.h"
 #include "capmap-range.h"
 
+#if __has_feature(capabilities)
+#include <cheriintrin.h>
+#else
+#error "capmap.h requires capabilities"
+#endif
+
+#include <stdio.h>
+
+#include <algorithm>
+#include <set>
+#include <utility>
+#include <vector>
+
+namespace capmap {
+
+// The primary container, and expected API entry point.
+class Mapper {
+ public:
+  // The default Mapper will scan all accessible memory where capabilities are
+  // found to it, but will not attempt to access unmapped pages, even if
+  // capabilities are found.
+  Mapper() : include_(LoadCapMap::vmmap()) {}
+
+  Mapper(SparseRange include) : include_(include) {}
+
+  // The number of dereference hops that are permitted when mapping a
+  // compartment.
+  //
+  // For example, setting `set_max_scan_depth(0)` causes the roots themselves to
+  // be incorporated, but they won't be dereferenced.
+  //
+  // This is available primarily as an optimisation for experimentation, since
+  // sparse purecap graphs could be expensive to construct. However, it may be
+  // acceptable in some applications for sensitive data to be indirectly
+  // reachable, for example if strict compartmentalisation is not required.
+  void set_max_scan_depth(uint64_t max) { max_scan_depth_ = max; }
+
+  // The maximum scan depth that was actually seen.
+  uint64_t max_seen_scan_depth() { return max_seen_scan_depth_; }
+
+  // Memory ranges to scan for indirect capabilities.
+  //
+  // Capabilities to memory outside included ranges will still be reported, but
+  // those ranges won't be examined.
+  SparseRange *include() { return &include_; }
+
+  // Scan the specified capability.
+  //
+  // The result is incorporated into the existing map.
+  void scan(void *__capability cap, char const *name) {
+    update_self_ranges();
+    if (cheri_tag_get(cap)) {
+      roots_.push_back(std::make_pair(name, cap));
+      scan(cap);
+    }
+  }
+
+  void print_json(FILE *stream);
+
+  LoadCapMap const &load_cap_map() const { return load_cap_map_; }
+
+  std::vector<std::unique_ptr<Map>> *maps() { return &maps_; }
+
+ private:
+  void update_self_ranges();
+  void scan(void *__capability cap, uint64_t depth = 0);
+
+  SparseRange include_;
+
+  // Memory ranges used by the mapper itself. These are updated during every
+  // scan, in case the `Mapper` moves or allocates.
+  SparseRange exclude_self_;
+
+  // We always track Load + LoadCaps, because we use it to walk the graph.
+  LoadCapMap load_cap_map_;
+
+  // User-configurable maps.
+  std::vector<std::unique_ptr<Map>> maps_;
+
+  uint64_t max_scan_depth_ = UINT64_MAX;
+  uint64_t max_seen_scan_depth_ = 0;
+
+  std::vector<std::pair<char const *, void *__capability>> roots_;
+};
+
+}  // namespace capmap
 #endif

--- a/src/capmap.cc
+++ b/src/capmap.cc
@@ -88,6 +88,13 @@ void print_raw_cap(FILE* stream, void* __capability cap) {
   fprintf(stream, "0x%u:%" PRIx64 ":%" PRIx64, cheri_tag_get(cap), parts[1], parts[0]);
 }
 
+void simple_scan_and_print_json(FILE* stream) {
+  Roots roots = get_roots();
+  Mapper mapper;
+  mapper.scan(roots);
+  mapper.print_json(stream);
+}
+
 void Mapper::update_self_ranges() {
   // TODO: Do a better job here.
   //  - We have several heap objects, which should also be excluded.

--- a/src/capmap.cc
+++ b/src/capmap.cc
@@ -221,4 +221,15 @@ SparseRange LoadCapMap::vmmap() {
   return map;
 }
 
+bool LoadMap::try_combine(void* __capability cap) {
+  if (!cheri_tag_get(cap)) return false;
+  if (cheri_is_sealed(cap)) return false;
+
+  if (cheri_perms_get(cap) & CHERI_PERM_LOAD) {
+    ranges_.combine(Range::from_cap(cap));
+    return true;
+  }
+  return false;
+}
+
 }  // namespace capmap

--- a/src/capmap.cc
+++ b/src/capmap.cc
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#include "include/capmap.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+
+// BSD headers for kinfo_getvmmap.
+#include <libutil.h>
+#include <sys/types.h>
+#include <sys/user.h>
+#include <unistd.h>
+
+#if __has_feature(capabilities)
+#include <cheriintrin.h>
+#else
+#error "capmap.cc requires capabilities"
+#endif
+
+// If greater than zero, print scan-related debug message to stderr.
+// This can help to diagnose why something is or isn't being found, but it
+// occurs before coalescing and redundancy checks, so is very verbose.
+#define SCAN_LOG_VERBOSITY 0
+
+#if SCAN_LOG_VERBOSITY > 0
+#define SCAN_LOG(verbosity, ...)             \
+  do {                                       \
+    if ((verbosity) <= SCAN_LOG_VERBOSITY) { \
+      fprintf(stderr, __VA_ARGS__);          \
+    }                                        \
+  } while (0)
+#else
+#define SCAN_LOG(...)
+#endif
+
+namespace capmap {
+
+void print_raw_cap(FILE* stream, void* __capability cap) {
+  uint64_t parts[2];
+  static_assert(sizeof(parts) == sizeof(cap), "Expected 128-bit capability");
+  memcpy(parts, &cap, sizeof(parts));
+  fprintf(stream, "0x%u:%" PRIx64 ":%" PRIx64, cheri_tag_get(cap), parts[1], parts[0]);
+}
+
+void Mapper::update_self_ranges() {
+  // TODO: Do a better job here.
+  //  - We have several heap objects, which should also be excluded.
+  //  - If using scan(Roots), we might want to exclude invariant regions once,
+  //    and update the exclusion ranges only when we allocate new map entries,
+  //    etc.
+  exclude_self_ = SparseRange();
+  exclude_self_.combine(Range::from_object(this));
+}
+
+void Mapper::scan(void* __capability cap, uint64_t depth) {
+  SCAN_LOG(1, "scan(%#lp, %" PRIu64 ")\n", cap, depth);
+  if (depth > max_seen_scan_depth_) max_seen_scan_depth_ = depth;
+
+  for (auto& map : maps_) map->try_combine(cap);
+
+  // TODO: Defer this until after the depth check and the
+  // load_cap_map_.try_combine() permissions check (but before the actual
+  // combination).
+  auto cap_range = Range::from_cap(cap);
+  auto scan_ranges = SparseRange(cap_range);
+  scan_ranges.remove(load_cap_map_.ranges());
+  scan_ranges.remove(exclude_self_);
+  // TODO: Make a SparseRange::filter() function or similar, to avoid repeating
+  // this for every scan.
+  auto exclude = SparseRange(Range::full_64bit());
+  exclude.remove(include_);
+  scan_ranges.remove(exclude);
+
+  if (load_cap_map_.try_combine(cap) && (depth < max_scan_depth_)) {
+    for (auto scan_range : scan_ranges.parts()) {
+      scan_range.shrink_to_alignment(sizeof(void* __capability));
+      ptraddr_t last = cheri_align_down(scan_range.last(), sizeof(void* __capability));
+      for (ptraddr_t next = scan_range.base(); next <= last; next += sizeof(void* __capability)) {
+        void* __capability candidate_cap;
+        asm("ldr %w[candidate], [%w[addr]]\n"
+            : [candidate] "=r"(candidate_cap)
+            : [addr] "r"(cheri_address_set(cap, next)));
+        if (cheri_tag_get(candidate_cap)) {
+          SCAN_LOG(2, "Recursing at %zx: %#lp\n", next, candidate_cap);
+          scan(candidate_cap, depth + 1);
+        } else {
+          SCAN_LOG(2, "No cap at %zx.\n", next);
+        }
+      }
+    }
+  }
+}
+
+void Mapper::print_json(FILE* stream) {
+  fprintf(stream, "\"capmap\": {\n");
+
+  {
+    char const* sep = "\n        ";
+    fprintf(stream, "    \"roots\": {");
+    for (auto const& name_cap : roots_) {
+      fprintf(stream, "%s\"%s\": \"", sep, name_cap.first);
+      print_raw_cap(stream, name_cap.second);
+      fprintf(stream, "\"");
+      sep = ",\n        ";
+    }
+    fprintf(stream, "\n    }\n");
+  }
+
+  fprintf(stream, "    \"scan\": {\n");
+  fprintf(stream, "        \"include\": ");
+  include_.print_json(stream, "        ");
+  fprintf(stream, ",\n");
+  fprintf(stream, "        \"exclude\": ");
+  exclude_self_.print_json(stream, "        ");
+  fprintf(stream, ",\n");
+  fprintf(stream, "        \"depth\": %" PRIu64 "\n    },\n", max_seen_scan_depth());
+
+  fprintf(stream, "    \"maps\": {\n");
+  fprintf(stream, "        \"%s\": {\n", load_cap_map_.name());
+  fprintf(stream, "            \"address-space\": \"%s\",\n", load_cap_map_.address_space());
+  fprintf(stream, "            \"ranges\": ");
+  ::capmap::print_json(stream, load_cap_map_.ranges(), "            ");
+  for (auto const& map : maps_) {
+    fprintf(stream, ",\n        \"%s\":\n", map->name());
+    fprintf(stream, "            \"address-space\": \"%s\",\n", map->address_space());
+    fprintf(stream, "            \"ranges\": ");
+    ::capmap::print_json(stream, map->ranges(), "            ");
+  }
+  fprintf(stream, "\n        }\n    }\n}\n");
+}
+
+bool LoadCapMap::try_combine(void* __capability cap) {
+  if (!cheri_tag_get(cap)) return false;
+  // TODO: Track sealed caps and see if we can unseal them later.
+  if (cheri_is_sealed(cap)) return false;
+
+  size_t const perms = CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP;
+  if ((cheri_perms_get(cap) & perms) != perms) return false;
+
+  ranges_.combine(Range::from_cap(cap));
+  return true;
+}
+
+bool LoadCapMap::includes_cap(ptraddr_t addr, ptraddr_t* cont) const {
+  // TODO: Abstract this in SparseRange somehow. This is just
+  // SparseRange::includes() with some extra logic using the intermediate value.
+  auto range = Range::from_base_length(addr, sizeof(void* __capability));
+  auto candidate = ranges_.parts().lower_bound(range);
+  if ((candidate != ranges_.parts().end()) && candidate->includes(range)) {
+    // TODO: Advance better, to avoid redundant checks in large ranges.
+    *cont = addr + sizeof(void* __capability);
+    return true;
+  }
+  return false;
+}
+
+SparseRange LoadCapMap::vmmap() {
+  pid_t pid = getpid();
+  int count;
+  kinfo_vmentry const* vm = kinfo_getvmmap(pid, &count);
+  SparseRange map;
+  for (int i = 0; i < count; i++) {
+    auto prot = vm[i].kve_protection;
+    if ((prot & KVME_PROT_READ) && (prot & KVME_PROT_READ_CAP)) {
+      map.combine(Range::from_base_limit(vm[i].kve_start, vm[i].kve_end));
+    }
+  }
+  return map;
+}
+
+}  // namespace capmap

--- a/src/range.cc
+++ b/src/range.cc
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#include <stdio.h>
+
+#include <limits>
+#include <utility>
+
+#include "include/capmap.h"
+
+namespace capmap {
+
+Range Range::from_cap(void* __capability cap) {
+  ptraddr_t base = cheri_base_get(cap);
+  size_t length = cheri_length_get(cap);
+
+  // As a special case: if the real length is 2^64, `cheri_length_get()`
+  // saturates to (2^64)-1. This length cannot be encoded in a compressed
+  // capability, so we can detect this case unambiguously.
+  if ((base == 0) && (length == std::numeric_limits<size_t>::max())) {
+    return Range::from_base_last(0, -1);
+  }
+
+  return Range::from_base_length(base, length);
+}
+
+bool Range::try_combine(Range other) {
+  if (overlaps(other) || preceeds(other) || follows(other)) {
+    base_ = std::min(base_, other.base_);
+    last_ = std::max(last_, other.last_);
+    return true;
+  }
+  return false;
+}
+
+bool SparseRange::overlaps(Range other) const {
+  if (other.is_empty()) return false;
+  // Sub-ranges are disjoint and non-adjacent, so if we overlap with `other` at
+  // all, we must do so with either the range that ends before `other`, or the
+  // range that ends with or after it.
+  auto range = ranges_.lower_bound(other);
+  if (range != ranges_.end()) {
+    if (range->overlaps(other)) return true;
+  }
+  if (range != ranges_.begin()) {
+    --range;
+    if (range->overlaps(other)) return true;
+  }
+  return false;
+}
+
+bool SparseRange::includes(Range other) const {
+  if (other.is_empty()) return false;
+  // Sub-ranges are disjoint and non-adjacent, so if we include `other`, it is
+  // with exactly one range, which must be the first one that ends on or after
+  // it.
+  auto range = ranges_.lower_bound(other);
+  return (range != ranges_.end()) && range->includes(other);
+}
+
+void SparseRange::combine(Range other) {
+  if (other.is_empty()) return;
+  if (ranges_.empty()) {
+    ranges_.insert(other);
+    return;
+  }
+
+  // Find the first and last ranges that could be combined with `other` (if any
+  // can). The iterators are bidirectional, so we can start with a fast and
+  // simple look up, then search linearly.
+  auto repl_start = ranges_.lower_bound(other);
+  // If we can't combine with the lower_bound(), try the previous one (if there
+  // is one).
+  if ((repl_start == ranges_.end()) ||
+      ((repl_start != ranges_.begin()) && !other.try_combine(*repl_start))) {
+    --repl_start;
+  }
+  auto repl_end = repl_start;
+
+  // Scan and combine in each direction.
+  // - Put repl_start at the first replaceable range.
+  // - Put repl_end just past the last replaceable range (or at the `end()`).
+  // If no ranges are replaceable, leave `repl_end == repl_start`.
+  while (repl_start != ranges_.begin()) {
+    auto prev = repl_start;
+    --prev;
+    if (other.try_combine(*prev)) {
+      repl_start = prev;
+    } else {
+      break;
+    }
+  }
+  while (repl_end != ranges_.end()) {
+    if (other.try_combine(*repl_end)) {
+      ++repl_end;
+    } else {
+      break;
+    }
+  }
+
+  ranges_.erase(repl_start, repl_end);
+  ranges_.insert(other);
+}
+
+void SparseRange::remove(Range other) {
+  if (other.is_empty()) return;
+  if (ranges_.empty()) return;
+
+  // Find the first and last ranges that overlap `other` (if any do).
+  auto repl_start = ranges_.lower_bound(other);
+  if ((repl_start == ranges_.end()) ||
+      ((repl_start != ranges_.begin()) && !repl_start->overlaps(other))) {
+    --repl_start;
+  }
+
+  if ((repl_start == ranges_.end()) || !repl_start->overlaps(other)) return;
+  auto repl_end = repl_start;
+
+  // Scan in each direction.
+  // - Put repl_start at the first replaceable range.
+  // - Put repl_last at the last replaceable range, and repl_end just past it.
+  while (repl_start != ranges_.begin()) {
+    auto prev = repl_start;
+    --prev;
+    if (prev->overlaps(other)) {
+      repl_start = prev;
+    } else {
+      break;
+    }
+  }
+  auto repl_last = repl_end++;
+  while (repl_end != ranges_.end()) {
+    if (!repl_end->overlaps(other)) break;
+    repl_last = repl_end++;
+  }
+
+  Range l;
+  Range h;
+  if (repl_start->base() < other.base()) {
+    l = Range::from_base_limit(repl_start->base(), other.base());
+  }
+  if (other.last() < repl_last->last()) {
+    h = Range::from_base_last(other.last() + 1, repl_last->last());
+  }
+
+  ranges_.erase(repl_start, repl_end);
+  if (!l.is_empty()) ranges_.insert(l);
+  if (!h.is_empty()) ranges_.insert(h);
+}
+
+void print_json(FILE* stream, std::set<Range> const& ranges, char const* line_prefix) {
+  switch (ranges.size()) {
+    case 0:
+      fprintf(stream, "[]");
+      return;
+    case 1:
+      fprintf(stream, "[ { \"base\": 0x%zx, \"last\": 0x%zx } ]", ranges.begin()->base(),
+              ranges.begin()->last());
+      return;
+  }
+  fprintf(stream, "[");
+  char const* sep = "\n";
+  for (auto const part : ranges) {
+    fprintf(stream, "%s%s    { \"base\": 0x%zx, \"last\": 0x%zx }", sep, line_prefix, part.base(),
+            part.last());
+    sep = ",\n";
+  }
+  fprintf(stream, "\n%s]", line_prefix);
+}
+
+}  // namespace capmap

--- a/test.sh
+++ b/test.sh
@@ -16,12 +16,18 @@ fi
 
 make -j10
 ssh -q "$SSHHOST" mkdir -p "$REMOTEDIR"
-scp -q *.so test-* "$SSHHOST":"$REMOTEDIR/"
+scp -q *.so test-* example-*-morello-* "$SSHHOST":"$REMOTEDIR/"
 if [ -z "${NORUN+norun}" ]; then
   ssh "$SSHHOST" "set -eu;
                   cd $REMOTEDIR;
                   ./test-morello-purecap;
-                  ./test-morello-hybrid;"
+                  ./test-morello-hybrid;
+                  echo -n \"Running example-default-morello-purecap... \";
+                  ./example-default-morello-purecap > /dev/null;
+                  echo \"Ok\";
+                  echo -n \"Running example-default-morello-hybrid... \";
+                  ./example-default-morello-hybrid > /dev/null;
+                  echo \"Ok\";"
 else
   echo "Skipping test run because NORUN is set."
 fi

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+set -eu
+
+SSHHOST="${SSHHOST:?Set SSHHOST to the hostname of a Morello machine (or model).}"
+REMOTEDIR="${REMOTEDIR:-capmap}"
+
+if [ -z "${NOFMT+nofmt}" ]; then
+  make clang-format-check
+else
+  echo "Skipping clang-format check because NOFMT is set."
+fi
+
+make -j10
+ssh -q "$SSHHOST" mkdir -p "$REMOTEDIR"
+scp -q *.so test-* "$SSHHOST":"$REMOTEDIR/"
+if [ -z "${NORUN+norun}" ]; then
+  ssh "$SSHHOST" "set -eu;
+                  cd $REMOTEDIR;
+                  ./test-morello-purecap;
+                  ./test-morello-hybrid;"
+else
+  echo "Skipping test run because NORUN is set."
+fi

--- a/tests/range.cc
+++ b/tests/range.cc
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#include "include/capmap-range.h"
+#include "tests.h"
+
+using capmap::Range;
+
+TEST(range_default) {
+  Range r;
+  TRY(r.is_empty());
+}
+
+TEST(range_min_min) {
+  Range r = Range::from_base_last(0, 0);
+  TRY(!r.is_empty());
+  TRY(r.base() == 0);
+  TRY(r.last() == 0);
+  TRY(r.limit().first == false);
+  TRY(r.limit().second == 1);
+  TRY(r.length().first == false);
+  TRY(r.length().second == 1);
+}
+
+TEST(range_max_max) {
+  Range r = Range::from_base_last(0xffffffffffffffff, 0xffffffffffffffff);
+  TRY(!r.is_empty());
+  TRY(r.base() == 0xffffffffffffffff);
+  TRY(r.last() == 0xffffffffffffffff);
+  TRY(r.limit().first == true);
+  TRY(r.limit().second == 0);
+  TRY(r.length().first == false);
+  TRY(r.length().second == 1);
+}
+
+TEST(range_min_max) {
+  Range r = Range::from_base_last(0, 0xffffffffffffffff);
+  TRY(!r.is_empty());
+  TRY(r.base() == 0);
+  TRY(r.last() == 0xffffffffffffffff);
+  TRY(r.limit().first == true);
+  TRY(r.limit().second == 0);
+  TRY(r.length().first == true);
+  TRY(r.length().second == 0);
+}
+
+TEST(range_min_empty) {
+  Range r = Range::from_base_last(1, 0);
+  TRY(r.is_empty());
+  TRY(r.base() == 1);
+  TRY(r.last() == 0);
+  TRY(r.limit().first == false);
+  TRY(r.limit().second == 1);
+  TRY(r.length().first == false);
+  TRY(r.length().second == 0);
+}
+
+TEST(range_42_empty) {
+  Range r = Range::from_base_last(42, 0);
+  TRY(r.is_empty());
+  TRY(r.base() == 42);
+  TRY(r.last() == 0);
+  TRY(r.limit().first == false);
+  TRY(r.limit().second == 1);
+  TRY(r.length().first == false);
+  TRY(r.length().second == 0);
+}
+
+TEST(range_from_base_limit) {
+  ptraddr_t values[] = {0, 1, 42, 0x8000'0000'0000, 0xff'ffff'ffff'ffff, 0xffff'ffff'ffff'fffe};
+  for (auto base : values) {
+    for (auto last : values) {
+      TRY(Range::from_base_last(base, last) == Range::from_base_limit(base, last + 1));
+    }
+  }
+}
+
+TEST(range_from_base_length) {
+  ptraddr_t values[] = {0, 1, 42, 0x8000'0000'0000, 0xff'ffff'ffff'ffff, 0xffff'ffff'ffff'fffe};
+  for (auto base : values) {
+    for (auto last : values) {
+      if (last >= base) {
+        TRY(Range::from_base_last(base, last) == Range::from_base_length(base, last - base + 1));
+      }
+    }
+  }
+}
+
+TEST(range_from_pcc) {
+  auto cap = cheri_pcc_get();
+  Range r = Range::from_cap(cap);
+  TRY(r.base() == cheri_base_get(cap));
+  if (cheri_length_get(cap) < 0xffff'ffff'ffff'ffff) {
+    TRY(r.length().first == false);
+    TRY(r.length().second == cheri_length_get(cap));
+  } else {
+    TRY(r.length().first == true);
+    TRY(r.length().second == 0);
+  }
+}
+
+TEST(range_from_object_u8) {
+  uint8_t o = 42;
+  auto r = Range::from_object(&o);
+  TRY(r.length().first == false);
+  TRY(r.length().second == 1);
+}
+
+TEST(range_from_object_u64) {
+  uint64_t o = 42;
+  auto r = Range::from_object(&o);
+  TRY(r.length().first == false);
+  TRY(r.length().second == 8);
+}
+
+TEST(range_from_object_u64x42) {
+  // This checks that array type information is propagated through the template.
+  uint64_t o[42] = {0};
+  auto r = Range::from_object(&o);
+  TRY(r.length().first == false);
+  TRY(r.length().second == (8 * 42));
+}
+
+TEST(range_shrink_to_alignment_nop) {
+  Range const r = Range::from_base_limit(42, 52);
+  TRY(r.shrunk_to_alignment(2) == r);
+}
+
+TEST(range_shrink_to_alignment_base) {
+  Range const r = Range::from_base_limit(41, 60);
+  TRY(r.shrunk_to_alignment(4) == Range::from_base_limit(44, 60));
+}
+
+TEST(range_shrink_to_alignment_limit) {
+  Range const r = Range::from_base_limit(44, 63);
+  TRY(r.shrunk_to_alignment(4) == Range::from_base_limit(44, 60));
+}
+
+TEST(range_shrink_to_alignment_both) {
+  Range const r = Range::from_base_limit(43, 61);
+  TRY(r.shrunk_to_alignment(4) == Range::from_base_limit(44, 60));
+}
+
+TEST(range_shrink_to_alignment_max) {
+  Range const r = Range::from_base_last(0, 0xffff'ffff'ffff'ffff);
+  TRY(r.shrunk_to_alignment(4) == r);
+}
+
+TEST(range_shrink_to_alignment_empty) {
+  // Empty ranges are unmodified by alignment, because the results aren't always
+  // representable.
+  Range const r = Range::from_base_last(3, 2);
+  TRY(r.shrunk_to_alignment(4) == r);
+}
+
+TEST(range_shrink_to_alignment_become_empty) {
+  Range r = Range::from_base_last(5, 6);
+  TRY(!r.is_empty());
+  TRY(r.length().first == false);
+  TRY(r.length().second == 2);
+  r.shrink_to_alignment(4);
+  TRY(r == Range::from_base_last(8, 3));
+  TRY(r.is_empty());
+  TRY(r.length().first == false);
+  TRY(r.length().second == 0);
+}
+
+TEST(range_combination_discontiguous) {
+  Range a = Range::from_base_last(42, 52);
+  Range b = Range::from_base_last(54, 64);
+  Range c = Range::from_base_last(66, 76);
+
+  TRY(!a.overlaps(b));
+  TRY(!a.overlaps(c));
+  TRY(!b.overlaps(a));
+  TRY(!b.overlaps(c));
+  TRY(!c.overlaps(a));
+  TRY(!c.overlaps(b));
+
+  TRY(!a.preceeds(b));
+  TRY(!a.preceeds(c));
+  TRY(!b.preceeds(a));
+  TRY(!b.preceeds(c));
+  TRY(!c.preceeds(a));
+  TRY(!c.preceeds(b));
+
+  TRY(!a.follows(b));
+  TRY(!a.follows(c));
+  TRY(!b.follows(a));
+  TRY(!b.follows(c));
+  TRY(!c.follows(a));
+  TRY(!c.follows(b));
+
+  TRY(!a.try_combine(b));
+  TRY(!a.try_combine(c));
+  TRY(!b.try_combine(a));
+  TRY(!b.try_combine(c));
+  TRY(!c.try_combine(a));
+  TRY(!c.try_combine(b));
+
+  TRY(a == Range::from_base_last(42, 52));
+  TRY(b == Range::from_base_last(54, 64));
+  TRY(c == Range::from_base_last(66, 76));
+}
+
+TEST(range_combination_contiguous) {
+  Range a = Range::from_base_last(42, 53);
+  Range b = Range::from_base_last(54, 65);
+  Range c = Range::from_base_last(66, 76);
+
+  TRY(!a.overlaps(b));
+  TRY(!a.overlaps(c));
+  TRY(!b.overlaps(a));
+  TRY(!b.overlaps(c));
+  TRY(!c.overlaps(a));
+  TRY(!c.overlaps(b));
+
+  TRY(a.preceeds(b));
+  TRY(!a.preceeds(c));
+  TRY(!b.preceeds(a));
+  TRY(b.preceeds(c));
+  TRY(!c.preceeds(a));
+  TRY(!c.preceeds(b));
+
+  TRY(!a.follows(b));
+  TRY(!a.follows(c));
+  TRY(b.follows(a));
+  TRY(!b.follows(c));
+  TRY(!c.follows(a));
+  TRY(c.follows(b));
+
+  TRY(!a.try_combine(c));
+  TRY(!c.try_combine(a));
+  TRY(a.try_combine(b));
+  TRY(a == Range::from_base_last(42, 65));
+  TRY(c.try_combine(a));
+  TRY(c == Range::from_base_last(42, 76));
+  TRY(b == Range::from_base_last(54, 65));  // Unmodified.
+}
+
+TEST(range_combination_overlapping) {
+  Range a = Range::from_base_last(42, 54);
+  Range b = Range::from_base_last(54, 66);
+  Range c = Range::from_base_last(66, 76);
+
+  TRY(a.overlaps(b));
+  TRY(!a.overlaps(c));
+  TRY(b.overlaps(a));
+  TRY(b.overlaps(c));
+  TRY(!c.overlaps(a));
+  TRY(c.overlaps(b));
+
+  TRY(!a.preceeds(b));
+  TRY(!a.preceeds(c));
+  TRY(!b.preceeds(a));
+  TRY(!b.preceeds(c));
+  TRY(!c.preceeds(a));
+  TRY(!c.preceeds(b));
+
+  TRY(!a.follows(b));
+  TRY(!a.follows(c));
+  TRY(!b.follows(a));
+  TRY(!b.follows(c));
+  TRY(!c.follows(a));
+  TRY(!c.follows(b));
+
+  TRY(!a.try_combine(c));
+  TRY(!c.try_combine(a));
+  TRY(a.try_combine(b));
+  TRY(a == Range::from_base_last(42, 66));
+  TRY(c.try_combine(a));
+  TRY(c == Range::from_base_last(42, 76));
+  TRY(b == Range::from_base_last(54, 66));  // Unmodified.
+}
+
+TEST(range_overlaps_includes) {
+  Range iii = Range::from_base_last(42, 420);
+  Range oi = Range::from_base_last(10, 50);
+  Range io = Range::from_base_last(400, 500);
+  Range i = Range::from_base_last(50, 400);
+  Range oiii = Range::from_base_last(41, 420);
+  Range iiio = Range::from_base_last(42, 421);
+
+  TRY(iii.overlaps(iii));
+  TRY(iii.overlaps(oi));
+  TRY(iii.overlaps(io));
+  TRY(iii.overlaps(i));
+  TRY(iii.overlaps(oiii));
+  TRY(iii.overlaps(iiio));
+
+  TRY(iii.includes(iii));
+  TRY(!iii.includes(oi));
+  TRY(!iii.includes(io));
+  TRY(iii.includes(i));
+  TRY(!iii.includes(oiii));
+  TRY(!iii.includes(iiio));
+
+  TRY(!iii.includes(41));
+  TRY(iii.includes(42));
+  TRY(iii.includes(420));
+  TRY(!iii.includes(421));
+}

--- a/tests/scan.cc
+++ b/tests/scan.cc
@@ -254,3 +254,15 @@ TEST(scan_loop) {
   // Depth 2: scan b, find &a, which is already mapped.
   TRY(mapper.max_seen_scan_depth() == 2);
 }
+
+TEST(scan_depth_zero) {
+  // If we limit the depth to zero, roots are never dereferenced, so we don't
+  // have to worry about the memory being mapped.
+  Mapper mapper{Range::full_64bit()};
+  mapper.set_max_scan_depth(0);
+  mapper.scan(capmap::get_roots());
+  if (options().verbose()) {
+    mapper.print_json(stdout);
+  }
+  TRY(mapper.max_seen_scan_depth() == 0);
+}

--- a/tests/scan.cc
+++ b/tests/scan.cc
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "include/capmap.h"
+#include "tests.h"
+
+using capmap::Mapper;
+using capmap::Range;
+using capmap::SparseRange;
+
+// Return a bounded capability for the object.
+//
+// Bounds are not guaranteed to be exact.
+//
+// For array types like `array[42]`, pass e.g. `&array`, not `array`; the latter
+// is interpreted as a pointer, and probably won't be given the bounds you expect.
+template <typename T = void* __capability, typename S>
+T* __capability cap(S* obj) {
+#ifdef __CHERI_PURE_CAPABILITY__
+  return reinterpret_cast<T* __capability>(obj);
+#else
+  auto ddc = cheri_ddc_get();
+  auto size = sizeof(S);
+  auto addr = reinterpret_cast<ptraddr_t>(obj);
+  auto ret = cheri_bounds_set(cheri_address_set(ddc, addr), size);
+  return reinterpret_cast<T* __capability>(ret);
+#endif
+}
+
+// Return just the address.
+//
+// This is like cheri_address_get(), but this works for hybrid pointers too.
+template <typename S>
+ptraddr_t addr(S* cap) {
+#ifdef __CHERI_PURE_CAPABILITY__
+  return cheri_address_get(cap);
+#else
+  return reinterpret_cast<ptraddr_t>(cap);
+#endif
+}
+
+TEST(scan_exclude_all) {
+  // If we don't include any ranges, we'll only gather roots.
+  uint64_t not_included[42] = {0};
+  void* __capability buffer[4] = {
+      nullptr,
+      nullptr,
+      cap(&not_included),
+      nullptr,
+  };
+
+  Mapper mapper{SparseRange()};
+
+  TRY(mapper.load_cap_map().ranges().empty());
+  mapper.scan(cap(&buffer), "&buffer");
+
+  if (options().verbose()) {
+    printf("&buffer: %#lp\n", cap(&buffer));
+    mapper.print_json(stdout);
+  }
+  auto ranges = mapper.load_cap_map().ranges();
+  TRY(ranges.size() == 1);
+  TRY(ranges.begin()->base() == addr(&buffer));
+  TRY(ranges.begin()->length().first == false);
+  TRY(ranges.begin()->length().second == sizeof(buffer));
+  // Roots do not overlap with any included memory.
+  TRY(mapper.max_seen_scan_depth() == 0);
+}
+
+TEST(scan_nested_not_detected) {
+  void* __capability not_detected[42] = {cheri_ddc_get()};
+  void* __capability nested[42] = {cap(&not_detected)};
+  void* __capability buffer[4] = {
+      nullptr,
+      nullptr,
+      nullptr,
+      cap(&nested),
+  };
+
+  SparseRange sr;
+  sr.combine(Range::from_object(&buffer));
+  // We'll never find a capability to not_detected; including it here shouldn't
+  // cause us to scan it.
+  sr.combine(Range::from_object(&not_detected));
+  Mapper mapper{sr};
+
+  TRY(mapper.load_cap_map().ranges().empty());
+  mapper.scan(cap(&buffer), "&buffer");
+
+  if (options().verbose()) {
+    printf("&not_detected: %#lp\n", cap(&not_detected));
+    printf("&nested: %#lp\n", cap(&nested));
+    printf("&buffer: %#lp\n", cap(&buffer));
+    mapper.print_json(stdout);
+  }
+  auto ranges = mapper.load_cap_map().ranges();
+  auto total_length = 0;
+  for (auto& range : ranges) {
+    TRY(range.length().first == false);
+    total_length += range.length().second;
+    TRY((range.base() == addr(&buffer)) || (range.base() == addr(&nested)));
+  }
+  TRY(total_length == (sizeof(buffer) + sizeof(nested)));
+  TRY((ranges.size() == 1) || (ranges.size() == 2));
+  TRY(!mapper.load_cap_map().sparse_range().overlaps(Range::from_object(&not_detected)));
+  // Depth 1: scan &buffer, find &nested, but it isn't included.
+  // We never find &detected.
+  TRY(mapper.max_seen_scan_depth() == 1);
+}
+
+TEST(scan_nested_detected) {
+  void* __capability detected[42] = {nullptr};
+  void* __capability nested[42] = {cap(&detected)};
+  void* __capability buffer[4] = {
+      nullptr,
+      nullptr,
+      nullptr,
+      cap(&nested),
+  };
+
+  SparseRange sr;
+  sr.combine(Range::from_object(&nested));
+  sr.combine(Range::from_object(&buffer));
+  Mapper mapper{sr};
+
+  TRY(mapper.load_cap_map().ranges().empty());
+  mapper.scan(cap(&buffer), "&buffer");
+
+  if (options().verbose()) {
+    printf("&detected: %#lp\n", cap(&detected));
+    printf("&nested: %#lp\n", cap(&nested));
+    printf("&buffer: %#lp\n", cap(&buffer));
+    mapper.print_json(stdout);
+  }
+  auto ranges = mapper.load_cap_map().ranges();
+  auto total_length = 0;
+  for (auto& range : ranges) {
+    TRY(range.length().first == false);
+    total_length += range.length().second;
+    TRY((range.base() == addr(&buffer)) || (range.base() == addr(&nested)) ||
+        (range.base() == addr(&detected)));
+  }
+  TRY(total_length == (sizeof(buffer) + sizeof(nested) + sizeof(detected)));
+  TRY((ranges.size() >= 1) && (ranges.size() <= 3));
+  TRY(mapper.load_cap_map().sparse_range().includes(Range::from_object(&buffer)));
+  TRY(mapper.load_cap_map().sparse_range().includes(Range::from_object(&nested)));
+  TRY(mapper.load_cap_map().sparse_range().includes(Range::from_object(&detected)));
+  // Depth 1: scan &buffer, find &nested.
+  // Depth 2: scan &nested, find &detected, but it isn't included.
+  TRY(mapper.max_seen_scan_depth() == 2);
+}
+
+TEST(scan_nested_depth_limit) {
+  // As TEST(scan_nested), but limit the depth so we don't see everything.
+  void* __capability too_deep[42] = {nullptr};
+  void* __capability nested[42] = {cap(&too_deep)};
+  void* __capability buffer[4] = {
+      nullptr,
+      nullptr,
+      nullptr,
+      cap(&nested),
+  };
+
+  SparseRange sr;
+  sr.combine(Range::from_object(&nested));
+  sr.combine(Range::from_object(&buffer));
+  Mapper mapper{sr};
+  // Scan the root (`&buffer`) and `buffer[..]` itself, but not `nested[..]`.
+  mapper.set_max_scan_depth(1);
+
+  TRY(mapper.load_cap_map().ranges().empty());
+  mapper.scan(cap(&buffer), "&buffer");
+
+  if (options().verbose()) {
+    printf("&too_deep: %#lp\n", cap(&too_deep));
+    printf("&nested: %#lp\n", cap(&nested));
+    printf("&buffer: %#lp\n", cap(&buffer));
+    mapper.print_json(stdout);
+  }
+  auto ranges = mapper.load_cap_map().ranges();
+  auto total_length = 0;
+  for (auto& range : ranges) {
+    TRY(range.length().first == false);
+    total_length += range.length().second;
+    TRY((range.base() == addr(&buffer)) || (range.base() == addr(&nested)));
+  }
+  TRY(total_length == (sizeof(buffer) + sizeof(nested)));
+  TRY((ranges.size() == 1) || (ranges.size() == 2));
+  TRY(mapper.load_cap_map().sparse_range().includes(Range::from_object(&buffer)));
+  TRY(mapper.load_cap_map().sparse_range().includes(Range::from_object(&nested)));
+  TRY(!mapper.load_cap_map().sparse_range().overlaps(Range::from_object(&too_deep)));
+  // Depth 1: scan &buffer, find &nested.
+  // Depth limit prevents further scans.
+  TRY(mapper.max_seen_scan_depth() == 1);
+}
+
+TEST(scan_self) {
+  void* __capability a;
+  a = cap(&a);
+
+  SparseRange sr;
+  sr.combine(Range::from_object(&a));
+  Mapper mapper{sr};
+
+  TRY(mapper.load_cap_map().ranges().empty());
+  mapper.scan(a, "a");
+
+  if (options().verbose()) {
+    printf("a (&a): %#lp\n", a);
+    mapper.print_json(stdout);
+  }
+  auto ranges = mapper.load_cap_map().ranges();
+  TRY(ranges.size() == 1);
+  TRY(ranges.begin()->base() == cheri_address_get(a));
+  TRY(ranges.begin()->length().first == false);
+  TRY(ranges.begin()->length().second == sizeof(a));
+  // Depth 1: scan a, find &a, which is already mapped.
+  TRY(mapper.max_seen_scan_depth() == 1);
+}
+
+TEST(scan_loop) {
+  void* __capability a;
+  void* __capability b = cap(&a);
+  a = cap(&b);
+
+  SparseRange sr;
+  sr.combine(Range::from_object(&a));
+  sr.combine(Range::from_object(&b));
+  Mapper mapper{sr};
+
+  TRY(mapper.load_cap_map().ranges().empty());
+  mapper.scan(a, "a");
+
+  if (options().verbose()) {
+    printf("a (&b): %#lp\n", a);
+    printf("b (&a): %#lp\n", b);
+    mapper.print_json(stdout);
+  }
+  auto ranges = mapper.load_cap_map().ranges();
+  auto total_length = 0;
+  for (auto& range : ranges) {
+    TRY(range.length().first == false);
+    total_length += range.length().second;
+    TRY((range.base() == cheri_address_get(a)) || (range.base() == cheri_address_get(b)));
+  }
+  TRY(total_length == (sizeof(a) + sizeof(b)));
+  TRY((ranges.size() == 1) || ranges.size() == 2);
+  TRY(mapper.load_cap_map().sparse_range().includes(Range::from_cap(a)));
+  TRY(mapper.load_cap_map().sparse_range().includes(Range::from_cap(b)));
+  // Depth 1: scan a, find &b
+  // Depth 2: scan b, find &a, which is already mapped.
+  TRY(mapper.max_seen_scan_depth() == 2);
+}

--- a/tests/sparse-range.cc
+++ b/tests/sparse-range.cc
@@ -1,0 +1,634 @@
+// SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#include <stdlib.h>
+
+#include "include/capmap-range.h"
+#include "tests.h"
+
+using capmap::Range;
+using capmap::SparseRange;
+
+TEST(sparse_range_simple) {
+  Range ranges[] = {
+      Range::from_base_last(42, 420),
+      Range::full_64bit(),
+      Range::from_base_last(0, 0),
+      Range::from_base_last(0xffffffffffffffff, 0xffffffffffffffff),
+  };
+  for (auto r : ranges) {
+    print_range_hex("  ", r, "\n");
+    SparseRange sr(r);
+    TRY(sr.overlaps(r));
+    TRY(sr.includes(r));
+    TRY(sr.parts().size() == 1);
+    TRY(sr.parts().count(r) == 1);
+  }
+}
+
+TEST(sparse_range_empty) {
+  SparseRange sr;
+  TRY(!sr.overlaps(Range::from_base_last(0, 0)));
+  TRY(!sr.includes(Range::from_base_last(0, 0)));
+  TRY(sr.parts().empty());
+}
+
+TEST(sparse_range_combine_empty) {
+  Range r = Range::from_base_last(42, 420);
+  SparseRange sr;
+  sr.combine(r);
+  TRY(sr == SparseRange(r));
+}
+
+//   [---l---]
+// +             [----h----]
+TEST(sparse_range_combine_disjoint) {
+  Range a = Range::from_base_last(42, 420);
+  Range b = Range::from_base_last(4200, 42000);
+  SparseRange sr(a);
+  sr.combine(b);
+  TRY(sr.overlaps(a));
+  TRY(sr.overlaps(b));
+  TRY(sr.includes(a));
+  TRY(sr.includes(b));
+
+  TRY(sr.overlaps(Range::from_base_last(420, 421)));
+  TRY(sr.overlaps(Range::from_base_last(4199, 4200)));
+  TRY(!sr.overlaps(Range::from_base_last(421, 4199)));
+  TRY(!sr.includes(Range::from_base_last(420, 421)));
+  TRY(!sr.includes(Range::from_base_last(4199, 4200)));
+  TRY(!sr.includes(Range::from_base_last(421, 4199)));
+  TRY(sr.parts().size() == 2);
+  TRY(*sr.parts().find(a) == a);
+  TRY(*sr.parts().find(b) == b);
+}
+
+//               [----h----]
+// + [---l---]
+TEST(sparse_range_combine_overlap_lh) {
+  Range l = Range::from_base_last(10, 50);
+  Range h = Range::from_base_last(42, 420);
+  print_range_dec("l = ", l, "\n");
+  print_range_dec("h = ", h, "\n");
+
+  SparseRange lh(l);
+  lh.combine(h);
+  print_sparse_range_dec("{h,l} = ", lh, "\n");
+  TRY(lh.overlaps(l));
+  TRY(lh.overlaps(h));
+  TRY(lh.includes(l));
+  TRY(lh.includes(h));
+  TRY(lh.parts().size() == 1);
+}
+
+//         [----h----]
+// + [---l---]
+// = [------lh-------]
+TEST(sparse_range_combine_overlap_hl) {
+  Range l = Range::from_base_last(10, 50);
+  Range h = Range::from_base_last(42, 420);
+  print_range_dec("l = ", l, "\n");
+  print_range_dec("h = ", h, "\n");
+
+  SparseRange hl(h);
+  hl.combine(l);
+  print_sparse_range_dec("{h,l} = ", hl, "\n");
+  TRY(hl.overlaps(l));
+  TRY(hl.overlaps(h));
+  TRY(hl.includes(l));
+  TRY(hl.includes(h));
+  TRY(hl.parts().size() == 1);
+}
+
+//            [---l---]     [----h----]
+// + [--n--]
+TEST(sparse_range_combine_disjoint_nlh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(42, 98);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{n,l,h}: ", sr, "\n");
+  TRY(sr.includes(n));
+  TRY(sr.includes(l));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 3);
+}
+
+//            [---l---]     [----h----]
+// +   [--n--]
+// =   [------nl------]     [----h----]
+TEST(sparse_range_combine_adjacent_nlh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(42, 99);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{n,l,h}: ", sr, "\n");
+  TRY(sr.includes(n));
+  TRY(sr.includes(l));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//            [---l---]     [----h----]
+// +   [---n---]
+// =   [------nl------]     [----h----]
+TEST(sparse_range_combine_overlap_nlh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(42, 100);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{n,l,h}: ", sr, "\n");
+  TRY(sr.includes(n));
+  TRY(sr.includes(l));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//            [---l---]     [----h----]
+// +   [------n-------]
+// =   [------nl------]     [----h----]
+TEST(sparse_range_combine_extend_nlh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(42, 199);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{n,l,h}: ", sr, "\n");
+  TRY(sr.includes(n));
+  TRY(sr.includes(l));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//            [---l---]     [----h----]
+// +   [--------n--------]
+// =   [--------n--------]  [----h----]
+TEST(sparse_range_combine_replace_nlh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(42, 249);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{n,l,h}: ", sr, "\n");
+  TRY(sr.includes(n));
+  TRY(sr.includes(l));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]         [----h----]
+// +               [--n--]
+// =     [---l---] [--n--] [----h----]
+TEST(sparse_range_combine_disjoint_lnh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(201, 298);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 3);
+}
+
+//       [---l---]         [----h----]
+// +              [---n--]
+// =     [-------ln------] [----h----]
+TEST(sparse_range_combine_adjacent_llh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(200, 298);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]         [----h----]
+// +            [---n----]
+// =     [-------ln------] [----h----]
+TEST(sparse_range_combine_overlap_llh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(199, 298);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]         [----h----]
+// +     [-------n-------]
+// =     [-------ln------] [----h----]
+TEST(sparse_range_combine_extend_llh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(100, 298);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]         [----h----]
+// + [---------n---------]
+// = [---------n---------] [----h----]
+TEST(sparse_range_combine_replace_llh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(42, 298);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]         [----h----]
+// +               [---n--]
+// =     [---l---] [--------nh-------]
+TEST(sparse_range_combine_adjacent_lhh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(201, 299);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]         [----h----]
+// +               [---n----]
+// =     [---l---] [--------nh-------]
+TEST(sparse_range_combine_overlap_lhh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(201, 300);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]         [----h----]
+// +               [--------n--------]
+// =     [---l---] [--------nh-------]
+TEST(sparse_range_combine_extend_lhh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(201, 399);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]         [----h----]
+// +               [-----------n----------]
+// =     [---l---] [-----------n----------]
+TEST(sparse_range_combine_replace_lhh) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(201, 420);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]         [----h----]
+// +              [---n---]
+// =     [---------------------------]
+TEST(sparse_range_combine_fill_adjacent_nnn) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(200, 299);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 1);
+}
+
+//       [---l---]         [----h----]
+// +           [------n------]
+// =     [---------------------------]
+TEST(sparse_range_combine_fill_overlap_nnn) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(142, 342);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 1);
+}
+
+//       [---l---]         [----h----]
+// +     [------------n--------------]
+// =     [---------------------------]
+TEST(sparse_range_combine_fill_extend_nnn) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(100, 399);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  // All ranges should be merged.
+  TRY(sr.parts().size() == 1);
+}
+
+//       [---l---]         [----h----]
+// + [----------------n------------------]
+// =     [---------------------------]
+TEST(sparse_range_combine_fill_replce_nnn) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(42, 420);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,n,h}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(n));
+  TRY(sr.includes(h));
+  TRY(sr.parts().size() == 1);
+}
+
+//       [---l---]    [----h----]
+// +                              [---n---]
+// =     [---l---]    [----h----] [---n---]
+TEST(sparse_range_combine_disjoint_lhn) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(401, 420);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,h,n}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(h));
+  TRY(sr.includes(n));
+  TRY(sr.parts().size() == 3);
+}
+
+//       [---l---]    [----h----]
+// +                             [---n---]
+// =     [---l---]    [---------hn-------]
+TEST(sparse_range_combine_adjacent_lhn) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(400, 420);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,h,n}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(h));
+  TRY(sr.includes(n));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]    [----h----]
+// +                          [------n---]
+// =     [---l---]    [---------hn-------]
+TEST(sparse_range_combine_overlap_lhn) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(399, 420);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,h,n}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(h));
+  TRY(sr.includes(n));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]    [----h----]
+// +                  [----------n-------]
+// =     [---l---]    [---------hn-------]
+TEST(sparse_range_combine_extend_lhn) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(300, 420);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,h,n}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(h));
+  TRY(sr.includes(n));
+  TRY(sr.parts().size() == 2);
+}
+
+//       [---l---]    [----h----]
+// +               [----------n----------]
+// =     [---l---] [----------n----------]
+TEST(sparse_range_combine_replace_lhn) {
+  Range l = Range::from_base_last(100, 199);
+  Range h = Range::from_base_last(300, 399);
+  SparseRange sr;
+  sr.combine(l);
+  sr.combine(h);
+  print_sparse_range_dec("{l,h}: ", sr, "\n");
+
+  Range n = Range::from_base_last(242, 420);
+  print_range_dec("n: ", n, "\n");
+  sr.combine(n);
+  print_sparse_range_dec("{l,h,n}: ", sr, "\n");
+  TRY(sr.includes(l));
+  TRY(sr.includes(h));
+  TRY(sr.includes(n));
+  TRY(sr.parts().size() == 2);
+}
+
+TEST(sparse_range_combine_remove_fuzz) {
+  uint64_t reference = 0;
+  SparseRange sr;
+
+  const int iterations = 4096;
+  if (options().verbosity() >= 2) print_sparse_range_bitmap("  ", sr, "\n", 64);
+  for (int i = 0; i < iterations; i++) {
+    size_t base = (size_t)mrand48() % 64;
+    size_t len = (size_t)mrand48() % 8;
+    size_t last = base + len;
+    if (last > 63) last = 63;
+    uint64_t base_mask = (((uint64_t)1 << base) - 1);
+    uint64_t last_mask = ((((uint64_t)1 << last) << 1) - 1);
+
+    Range r = Range::from_base_last(base, last);
+    if ((i < 16) || (mrand48() % 2)) {
+      sr.combine(r);
+      reference |= (base_mask ^ last_mask);
+    } else {
+      sr.remove(r);
+      reference &= ~(base_mask ^ last_mask);
+    }
+    if (options().verbosity() >= 2) {
+      print_sparse_range_bitmap("  ", sr, "  ", 64, r);
+      print_sparse_range_dec("", sr, "\n");
+    }
+
+    // Verify sub-range properties.
+    Range prev;
+    for (auto& range : sr.parts()) {
+      if (!prev.is_empty()) {
+        TRY(prev < range);
+        TRY(!prev.overlaps(range));
+        TRY(!prev.preceeds(range));
+      }
+      TRY(!range.is_empty());
+      prev = range;
+    }
+
+    // Check that the bitmask matches.
+    uint64_t check = 0;
+    for (size_t bit = 0; bit < 64; bit++) {
+      if (sr.includes(bit)) {
+        check |= (uint64_t)1 << bit;
+      }
+    }
+    TRY(check == reference);
+  }
+}

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -29,6 +29,89 @@ int TestRun::printf(char const *fmt, ...) {
   return result;
 }
 
+extern "C" void *__capability map_load_only_impl(TestRun *self) {
+  size_t length = 42 * 4096;
+  void *ptr = mmap(nullptr, length, PROT_READ, MAP_ANONYMOUS, -1, 0);
+#ifdef __CHERI_PURE_CAPABILITY__
+  void *__capability cap = cheri_perms_and(ptr, CHERI_PERM_LOAD);
+#else
+  auto addr = reinterpret_cast<ptraddr_t>(ptr);
+  void *__capability cap = cheri_address_set(cheri_ddc_get(), addr);
+  cap = cheri_bounds_set_exact(cap, length);
+  cap = cheri_perms_and(cap, CHERI_PERM_LOAD);
+#endif
+  if (self->options().verbose()) {
+    self->printf("map_load_only() -> %#lp\n", ptr);
+  }
+  return cap;
+}
+
+// Get a capability with load, but not load-capability permissions, and make
+// some effort to clean up temporaries, etc.
+//
+// This is not expected to be reliable enough for security purposes, but is good
+// enough for tests.
+__attribute((naked)) void *__capability TestRun::map_load_only() {
+  // AAPCS64(-cap):
+  //    c0/x0: `this`
+  // The result is returned in c0.
+  // clang-format off
+  asm(
+#ifdef __CHERI_PURE_CAPABILITY__
+      "str  clr, [csp, #-16]!\n"
+#else
+      "stp  lr, xzr, [sp, #-16]!\n"
+#endif
+      "bl   map_load_only_impl\n"
+      // Scrub all caller-saved capability registers except:
+      //  - c0, which holds the result,
+      //  - c17, which we'll use to scrub the stack,
+      //  - and clr, which we're going to restore anyway.
+      "mov  x1, #0\n"
+      "mov  x2, #0\n"
+      "mov  x3, #0\n"
+      "mov  x4, #0\n"
+      "mov  x5, #0\n"
+      "mov  x6, #0\n"
+      "mov  x7, #0\n"
+      "mov  x8, #0\n"
+      "mov  x9, #0\n"
+      "mov  x10, #0\n"
+      "mov  x11, #0\n"
+      "mov  x12, #0\n"
+      "mov  x13, #0\n"
+      "mov  x14, #0\n"
+      "mov  x15, #0\n"
+      "mov  x16, #0\n"
+      // Scrub a section of stack. For our purposes, we just hope that this is
+      // enough, and the worst that will happen is that a test might fail. For
+      // security-sensitive applications, the actual stack used should be
+      // measured or restricted somehow.
+#ifdef __CHERI_PURE_CAPABILITY__
+      // Assume that purecap implies C64.
+      "sub  c17, csp, #(32 * 100)\n"
+      "1:\n"
+      "stp  czr, czr, [c17], #32\n"
+      "cmp  sp, x17\n"
+      "b.hi 1b\n"
+
+      "ldr  clr, [csp], #16\n"
+      "ret  clr\n"
+#else
+      // Assume that hybrid implies A64.
+      "sub  x17, sp, #(32 * 100)\n"
+      "1:\n"
+      "stp  xzr, xzr, [x17], #16\n"
+      "cmp  sp, x17\n"
+      "b.hi 1b\n"
+
+      "ldp  lr, xzr, [sp], #16\n"
+      "ret  lr\n"
+#endif
+      );
+  // clang-format on
+}
+
 bool Options::parse_arg(char const *arg) {
   if (arg[0] == '-') {
     if (arg[1] == '-') {

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#include "tests.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <sys/mman.h>
+
+#include "include/capmap.h"
+
+using capmap::tests::Options;
+using capmap::tests::Test;
+using capmap::tests::TestRun;
+
+std::vector<Test *> &Test::list() {
+  static std::vector<Test *> singleton;
+  return singleton;
+}
+
+int TestRun::printf(char const *fmt, ...) {
+  if (!options().verbose()) return 0;
+  if (!printed_) notify_print();
+
+  va_list args;
+  va_start(args, fmt);
+  int result = vprintf(fmt, args);
+  va_end(args);
+  return result;
+}
+
+bool Options::parse_arg(char const *arg) {
+  if (arg[0] == '-') {
+    if (arg[1] == '-') {
+      // Long options.
+      if (strcmp(arg, "--verbose") == 0) {
+        verbosity_++;
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      // Short options.
+      char const *c = &arg[1];
+      do {
+        switch (*c) {
+          case 'v':
+            verbosity_++;
+            break;
+          default:
+            return false;
+        }
+      } while (*(++c) != '\0');
+      return true;
+    }
+  } else {
+    filter_needles_.push_back(arg);
+    return true;
+  }
+}
+
+bool Options::should_run(char const *name) const {
+  if (filter_needles_.empty()) return true;
+  for (char const *needle : filter_needles_) {
+    if (strstr(name, needle)) return true;
+  }
+  return false;
+}
+
+int main(int argc, char const *argv[]) {
+  int pass = 0;
+  int fail = 0;
+  Options options;
+  for (int i = 1; i < argc; i++) {
+    if (!options.parse_arg(argv[i])) {
+      fprintf(stderr, "Bad argument: %s\n", argv[i]);
+      exit(1);
+    }
+  }
+  for (Test *test : Test::list()) {
+    if (!options.should_run(test->name())) continue;
+    printf("%s... ", test->name());
+    fflush(stdout);
+    auto run = test->run(options);
+    if (run.printed()) {
+      printf("  ");
+    }
+    if (run.passed()) {
+      printf("\033[1;32mPASS\033[m\n");
+      pass++;
+    } else {
+      printf("\033[1;31mFAIL\033[m\n");
+      fail++;
+    }
+  }
+  printf("Tests complete: %d passed, %d failed\n", pass, fail);
+  return 0;
+}

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#ifndef TESTS_H_
+#define TESTS_H_
+
+#include <stdio.h>
+
+#include <vector>
+
+#include "include/capmap.h"
+
+namespace capmap {
+namespace tests {
+
+class Options {
+ public:
+  bool parse_arg(char const *arg);
+
+  bool verbose() const { return verbosity_ > 0; }
+  int verbosity() const { return verbosity_; }
+  bool should_run(char const *name) const;
+
+ private:
+  int verbosity_ = 0;
+  std::vector<char const *> filter_needles_;
+};
+
+class TestRun {
+ public:
+  bool passed() { return result_; }
+  bool printed() const { return printed_; }
+
+  int printf(char const *fmt, ...);
+  Options const &options() { return options_; }
+
+ protected:
+  TestRun(Options const &options) : options_{options} {}
+
+  void notify_print() {
+    // We try to print "test... " then "PASS\n", so if the test prints something
+    // we need to add a newline first.
+    ::printf("\n");
+    printed_ = true;
+  }
+
+  void print_range_dec(char const *prefix, const Range &range, char const *suffix) {
+    printf("%s[%zu,%zu]%s", prefix, range.base(), range.last(), suffix);
+  }
+
+  void print_range_hex(char const *prefix, const Range &range, char const *suffix) {
+    printf("%s[%#zx,%#zx]%s", prefix, range.base(), range.last(), suffix);
+  }
+
+  void print_sparse_range_dec(char const *prefix, const SparseRange &sr, char const *suffix) {
+    const char *sep = "";
+    printf("%s", prefix);
+    for (auto const &range : sr.parts()) {
+      print_range_dec(sep, range, "");
+      sep = ", ";
+    }
+    printf("%s", suffix);
+  }
+
+  void print_sparse_range_bitmap(char const *prefix, const SparseRange &sr, char const *suffix,
+                                 size_t bits, Range hl_range = Range()) {
+    printf("%s", prefix);
+    size_t count = 0;
+    for (auto const &range : sr.parts()) {
+      for (; (count < range.base()) && (count < bits); count++) {
+        printf(hl_range.includes(count) ? "\033[31m-\033[m" : " ");
+      }
+      if (count >= bits) break;
+
+      for (; (count <= range.last()) && (count < bits); count++) {
+        printf(hl_range.includes(count) ? "\033[32m+\033[m" : "█");
+      }
+    }
+    for (; (count < bits); count++) {
+      printf(hl_range.includes(count) ? "\033[31m-\033[m" : " ");
+    }
+    printf("%s", suffix);
+  }
+
+  bool printed_ = false;
+  bool result_ = true;
+
+ private:
+  Options const &options_;
+};
+
+class Test {
+ public:
+  virtual ~Test() {}
+  virtual TestRun run(Options const &options) const = 0;
+  char const *name() const { return name_; }
+
+  static std::vector<Test *> &list();
+
+ protected:
+  Test(char const *name) : name_(name) { list().push_back(this); }
+  char const *name_;
+};
+
+#define TEST(name)                                                                             \
+  class TestRun_##name : public capmap::tests::TestRun {                                       \
+   public:                                                                                     \
+    TestRun_##name(capmap::tests::Options const &options) : capmap::tests::TestRun(options){}; \
+    void run();                                                                                \
+  };                                                                                           \
+  class Test_##name : public capmap::tests::Test {                                             \
+   public:                                                                                     \
+    Test_##name(char const *name) : capmap::tests::Test(name) {}                               \
+    virtual capmap::tests::TestRun run(                                                        \
+        capmap::tests::Options const &options) const override final {                          \
+      TestRun_##name runner(options);                                                          \
+      runner.run();                                                                            \
+      return runner;                                                                           \
+    }                                                                                          \
+  };                                                                                           \
+  Test_##name test_##name(#name);                                                              \
+  void TestRun_##name::run()
+
+#define TRY(expr)                                               \
+  do {                                                          \
+    if (!(expr)) {                                              \
+      printf("  `%s`\n", #expr);                                \
+      /* This expects to be called from some TestRun::run(). */ \
+      result_ = false;                                          \
+      return;                                                   \
+    }                                                           \
+  } while (0)
+
+}  // namespace tests
+}  // namespace capmap
+
+#endif

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -82,6 +82,13 @@ class TestRun {
     printf("%s", suffix);
   }
 
+  // Get a capability with load, but not load-capability permissions, and make
+  // some effort to clean up temporaries, etc.
+  //
+  // This is not expected to be reliable enough for security purposes, but is
+  // good enough for tests.
+  __attribute((naked)) void *__capability map_load_only();
+
   bool printed_ = false;
   bool result_ = true;
 


### PR DESCRIPTION
This implements enough to examine simple data mappings. For example, below are the default "load capabilities" mappings for the minimal example process. You can reproduce these by building the examples (`make`) and running them on a Morello/CheriBSD system.

## Purecap

```
    "maps": {
        "load capabilities": {
            "address-space": "virtual memory",
            "ranges": [
                { "base": 0x100000, "last": 0x130f3f },
                { "base": 0x40130000, "last": 0x401843ff },
                { "base": 0x40185000, "last": 0x4018dfff },
                { "base": 0x4018f000, "last": 0x40cfcfff },
                { "base": 0x60000000, "last": 0x601fffff },
                { "base": 0x80000000, "last": 0x805fffff },
                { "base": 0xffffbff7f770, "last": 0xffffbff7ff12 },
                { "base": 0xffffbff7ff20, "last": 0xffffbff7ff37 },
                { "base": 0xffffbff7ff40, "last": 0xffffbff7ffb9 },
                { "base": 0xffffbff7ffc0, "last": 0xfffffff7ffff }
            ]
        }
    }
```

## Hybrid

On hybrid, the DDC covers a very wide range of memory, so the results are simple:

```
    "maps": {
        "load capabilities": {
            "address-space": "virtual memory",
            "ranges": [ { "base": 0x0, "last": 0xffffffffffff } ]
        }
    }