### PR TITLE
New mapping types.

### DIFF
--- a/include/capmap.h
+++ b/include/capmap.h
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-FileCopyrightText: Copyright 2023 The University of Glasgow
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #ifndef CAPMAP_H_
@@ -108,7 +109,12 @@ class Mapper {
     update_self_ranges();
     if (cheri_tag_get(cap)) {
       roots_.push_back(std::make_pair(name, cap));
-      scan(cap);
+      try {
+        scan(cap);
+      } catch (int n) {
+        fprintf(stderr, " from root %s at depth %d\n", name, n);
+        abort();
+      }
     }
   }
 


### PR DESCRIPTION
Adds the following mapping types:

- `BasicMap` tracks capabilites with all of the specified permissons.

- `BranchMap` tracks all simple branch targets. Unsealed executable capabilities are added in full, while sentries are added as a length-1 range starting at the value of the sentry.

- `PoisonMap` is used to designate an 'off-limits' area. If an unsealed capability is encountered with any of the specified permissions whose bounds overlap with the poisoned region, the specified callback will be invoked. If that callback is null or returns nonzero, the chain of capabilities leading to the overlapping capability will be printed and the library will abort.